### PR TITLE
Fixes #121: Broken link on what-is-litmus page

### DIFF
--- a/website/versioned_docs/version-2.0.0/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-2.0.0/introduction/what-is-litmus.md
@@ -35,4 +35,4 @@ A chaos workflow is much more than a simple chaos experiment. It supports the us
 - If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
 - If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
 - If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work-with-developer-certificate-of-origin).


### PR DESCRIPTION
Fix #121.
Clicking on Sign you work should open: https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work-with-developer-certificate-of-origin
Presently it opens the correct GitHub page but wrong Heading is mentioned in the link

Signed-off-by: Pratik Borhade <pratikborhade302@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Signed the commit for DCO to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag
