### PR TITLE
Fixes #126: Missing links on chaos-workflow page

### DIFF
--- a/website/docs/concepts/chaos-workflow.md
+++ b/website/docs/concepts/chaos-workflow.md
@@ -14,8 +14,8 @@ A Chaos Workflow can also be used to perform different operations parallelly to 
 
 The following should be required before creating a Chaos Workflow:
 
-- ChaosCenter
-- ChaosAgent
+- [ChaosCenter](../getting-started/resources.md#chaoscenter)
+- [ChaosAgent](../getting-started/resources.md#chaosagents)
 - [Chaos Experiment CR](chaos-experiment.md)
 - [ChaosEngine CR](chaos-engine.md)
 - [Probes](probes.md)


### PR DESCRIPTION
Signed-off-by: Pratik Borhade <pratikborhade302@gmail.com>

Fix #126 
Under `Prerequisites` heading, check _ChaosCenter_ & _ChaosAgent_ (links are missing)

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Signed the commit for DCO to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag
