### PR TITLE
Functionality for Dark-Mode in Litmus Docs 2.0 

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -126,7 +126,7 @@ module.exports = {
 
       // Hides the switch in the navbar
       // Useful if you want to support a single color mode
-      disableSwitch: true,
+      disableSwitch: false,
 
       // Should we use the prefers-color-scheme media-query,
       // using user system preferences, instead of the hardcoded defaultMode

--- a/website/src/components/layout/Sections.jsx
+++ b/website/src/components/layout/Sections.jsx
@@ -1,20 +1,8 @@
 import React, { useState, useEffect } from 'react'
 import '../../css/sections.css'
 
-import useThemeContext from '@theme/hooks/useThemeContext';
-
 const SectionLight = ({ children }) => <div className="homeSection">{children}</div>
 
-const SectionDark = ({ children }) => {
-
-  const { isDarkTheme } = useThemeContext();
-  const [backgroundColor, setBackgroundColor] = useState(isDarkTheme ? '#1c1d1f' : '#f4f5f7')
-
-  useEffect(() => {
-    setBackgroundColor(isDarkTheme ? '#1c1d1f' : '#f4f5f7')
-  }, [isDarkTheme]);
-
-  return <div style={{ backgroundColor: backgroundColor }} className="homeSection">{children}</div>
-}
+const SectionDark = ({ children }) => <div className="homeSection">{children}</div>
 
 export { SectionLight, SectionDark }

--- a/website/src/components/layout/Sections.jsx
+++ b/website/src/components/layout/Sections.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import '../../css/sections.css'
 
 const SectionLight = ({ children }) => <div className="homeSection">{children}</div>

--- a/website/src/components/layout/Sections.jsx
+++ b/website/src/components/layout/Sections.jsx
@@ -1,8 +1,20 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import '../../css/sections.css'
 
-const SectionLight = ({ children }) => <div className="sectionLight">{children}</div>
+import useThemeContext from '@theme/hooks/useThemeContext';
 
-const SectionDark = ({ children }) => <div className="sectionDark">{children}</div>
+const SectionLight = ({ children }) => <div className="homeSection">{children}</div>
+
+const SectionDark = ({ children }) => {
+
+  const { isDarkTheme } = useThemeContext();
+  const [backgroundColor, setBackgroundColor] = useState(isDarkTheme ? '#1c1d1f' : '#f4f5f7')
+
+  useEffect(() => {
+    setBackgroundColor(isDarkTheme ? '#1c1d1f' : '#f4f5f7')
+  }, [isDarkTheme]);
+
+  return <div style={{ backgroundColor: backgroundColor }} className="homeSection">{children}</div>
+}
 
 export { SectionLight, SectionDark }

--- a/website/src/css/global.css
+++ b/website/src/css/global.css
@@ -7,7 +7,6 @@ html {
 body {
   margin: 0;
   padding: 0;
-  background: #f4f5f7;
   font-size: 1.05rem;
 }
 

--- a/website/src/css/sections.css
+++ b/website/src/css/sections.css
@@ -1,34 +1,17 @@
-.sectionLight {
-  background-color: #f9fafc;
+.homeSection {
   padding: 3rem 2rem;
 }
 
-.sectionLight > div {
-  width: 70%;
-  margin: 0 auto;
-}
-
-.sectionDark {
-  background-color: #f4f5f7;
-  padding: 3rem 2rem;
-}
-
-.sectionDark > div {
+.homeSection > div {
   width: 70%;
   margin: 0 auto;
 }
 
 @media (max-width: 890px) {
-  .sectionLight {
+  .homeSection {
     padding: 1rem 10%;
   }
-  .sectionLight > div {
-    width: 100%;
-  }
-  .sectionDark {
-    padding: 1rem 10%;
-  }
-  .sectionDark > div {
+  .homeSection > div {
     width: 100%;
   }
 }


### PR DESCRIPTION
Signed-off-by: neelanjan00 <neelanjan@chaosnative.com>

## What This PR Does
This PR enables dark mode throughout Litmus Docs 2.0

## Which Issue This PR Fixes 
Fixes litmuschaos/litmus#3232

**Notes:**
Changes introduced as part of this PR (in dark mode) causes a few diagrams in the `Architecture` section and `Concepts / Observability` section to render improperly as they have a transparent background. Separate PRs can be raised with appropriate fixes to render them properly in dark mode.

**Checklist:**
-   [x] Fixes #<issue number>
-   [x] Signed the commit for DCO to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag