### PR TITLE
Fixed Manifest link used in 2.13.0 docs

### DIFF
--- a/website/versioned_docs/version-2.11.0/user-guides/uninstall-litmus.md
+++ b/website/versioned_docs/version-2.11.0/user-guides/uninstall-litmus.md
@@ -105,7 +105,7 @@ To uninstall the ChaosCenter from the system, follow these steps -
   kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/2.11.0/mkdocs/docs/2.11.0/litmus-2.11.0.yaml
   ```
 
-  > To delete any specific version of the ChaosCenter, replace the above command with the below command. `kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/<VERSION>/mkdocs/docs/<VERSION/litmus-<VERSION>.yaml`
+  > To delete any specific version of the ChaosCenter, replace the above command with the below command. `kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/<VERSION>/mkdocs/docs/<VERSION>/litmus-<VERSION>.yaml`
 
 - **Litmus Master Manifest**
 

--- a/website/versioned_docs/version-2.12.0/user-guides/uninstall-litmus.md
+++ b/website/versioned_docs/version-2.12.0/user-guides/uninstall-litmus.md
@@ -105,7 +105,7 @@ To uninstall the ChaosCenter from the system, follow these steps -
   kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/2.12.0/mkdocs/docs/2.12.0/litmus-2.12.0.yaml
   ```
 
-  > To delete any specific version of the ChaosCenter, replace the above command with the below command. `kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/<VERSION>/mkdocs/docs/<VERSION/litmus-<VERSION>.yaml`
+  > To delete any specific version of the ChaosCenter, replace the above command with the below command. `kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/<VERSION>/mkdocs/docs/<VERSION>/litmus-<VERSION>.yaml`
 
 - **Litmus Master Manifest**
 

--- a/website/versioned_docs/version-2.13.0/user-guides/uninstall-litmus.md
+++ b/website/versioned_docs/version-2.13.0/user-guides/uninstall-litmus.md
@@ -102,7 +102,7 @@ To uninstall the ChaosCenter from the system, follow these steps -
 - **Litmus 2.13.0**
 
   ```bash
-  kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/2.13.0/docs/2.13.0/litmus-2.13.0.yaml
+  kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/2.13.0/mkdocs/docs/2.13.0/litmus-2.13.0.yaml
   ```
 
   > To delete any specific version of the ChaosCenter, replace the above command with the below command. `kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/<VERSION>/mkdocs/docs/<VERSION/litmus-<VERSION>.yaml`

--- a/website/versioned_docs/version-2.13.0/user-guides/uninstall-litmus.md
+++ b/website/versioned_docs/version-2.13.0/user-guides/uninstall-litmus.md
@@ -105,7 +105,7 @@ To uninstall the ChaosCenter from the system, follow these steps -
   kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/2.13.0/mkdocs/docs/2.13.0/litmus-2.13.0.yaml
   ```
 
-  > To delete any specific version of the ChaosCenter, replace the above command with the below command. `kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/<VERSION>/mkdocs/docs/<VERSION/litmus-<VERSION>.yaml`
+  > To delete any specific version of the ChaosCenter, replace the above command with the below command. `kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/<VERSION>/mkdocs/docs/<VERSION>/litmus-<VERSION>.yaml`
 
 - **Litmus Master Manifest**
 


### PR DESCRIPTION
Signed-off-by: Anirudh Sharma <anirudh1304@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Fixes Manifest link used in 2.13.0 docs

**Which issue this PR fixes** 
fixes https://github.com/litmuschaos/litmus/issues/3798

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Signed the commit for DCO to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag
