### PR TITLE
fix: Fixed spelling of 'ChaosCenter' in Sidebar Concepts section

### DIFF
--- a/website/docs/concepts/oauth-dex-concept.md
+++ b/website/docs/concepts/oauth-dex-concept.md
@@ -1,7 +1,7 @@
 ---
 id: oauth-dex-concept
 title: Authentication process in ChaosCenter
-sidebar_label: Authentication in ChoasCenter
+sidebar_label: Authentication in ChaosCenter
 ---
 
 ---

--- a/website/versioned_docs/version-2.10.0/concepts/oauth-dex-concept.md
+++ b/website/versioned_docs/version-2.10.0/concepts/oauth-dex-concept.md
@@ -1,7 +1,7 @@
 ---
 id: oauth-dex-concept
 title: Authentication process in ChaosCenter
-sidebar_label: Authentication in ChoasCenter
+sidebar_label: Authentication in ChaosCenter
 ---
 
 ---

--- a/website/versioned_docs/version-2.11.0/concepts/oauth-dex-concept.md
+++ b/website/versioned_docs/version-2.11.0/concepts/oauth-dex-concept.md
@@ -1,7 +1,7 @@
 ---
 id: oauth-dex-concept
 title: Authentication process in ChaosCenter
-sidebar_label: Authentication in ChoasCenter
+sidebar_label: Authentication in ChaosCenter
 ---
 
 ---

--- a/website/versioned_docs/version-2.12.0/concepts/oauth-dex-concept.md
+++ b/website/versioned_docs/version-2.12.0/concepts/oauth-dex-concept.md
@@ -1,7 +1,7 @@
 ---
 id: oauth-dex-concept
 title: Authentication process in ChaosCenter
-sidebar_label: Authentication in ChoasCenter
+sidebar_label: Authentication in ChaosCenter
 ---
 
 ---

--- a/website/versioned_docs/version-2.13.0/concepts/oauth-dex-concept.md
+++ b/website/versioned_docs/version-2.13.0/concepts/oauth-dex-concept.md
@@ -1,7 +1,7 @@
 ---
 id: oauth-dex-concept
 title: Authentication process in ChaosCenter
-sidebar_label: Authentication in ChoasCenter
+sidebar_label: Authentication in ChaosCenter
 ---
 
 ---

--- a/website/versioned_docs/version-2.3.0/concepts/oauth-dex-concept.md
+++ b/website/versioned_docs/version-2.3.0/concepts/oauth-dex-concept.md
@@ -1,7 +1,7 @@
 ---
 id: oauth-dex-concept
 title: Authentication process in ChaosCenter
-sidebar_label: Authentication in ChoasCenter
+sidebar_label: Authentication in ChaosCenter
 ---
 
 ---

--- a/website/versioned_docs/version-2.4.0/concepts/oauth-dex-concept.md
+++ b/website/versioned_docs/version-2.4.0/concepts/oauth-dex-concept.md
@@ -1,7 +1,7 @@
 ---
 id: oauth-dex-concept
 title: Authentication process in ChaosCenter
-sidebar_label: Authentication in ChoasCenter
+sidebar_label: Authentication in ChaosCenter
 ---
 
 ---

--- a/website/versioned_docs/version-2.5.0/concepts/oauth-dex-concept.md
+++ b/website/versioned_docs/version-2.5.0/concepts/oauth-dex-concept.md
@@ -1,7 +1,7 @@
 ---
 id: oauth-dex-concept
 title: Authentication process in ChaosCenter
-sidebar_label: Authentication in ChoasCenter
+sidebar_label: Authentication in ChaosCenter
 ---
 
 ---

--- a/website/versioned_docs/version-2.6.0/concepts/oauth-dex-concept.md
+++ b/website/versioned_docs/version-2.6.0/concepts/oauth-dex-concept.md
@@ -1,7 +1,7 @@
 ---
 id: oauth-dex-concept
 title: Authentication process in ChaosCenter
-sidebar_label: Authentication in ChoasCenter
+sidebar_label: Authentication in ChaosCenter
 ---
 
 ---

--- a/website/versioned_docs/version-2.7.0/concepts/oauth-dex-concept.md
+++ b/website/versioned_docs/version-2.7.0/concepts/oauth-dex-concept.md
@@ -1,7 +1,7 @@
 ---
 id: oauth-dex-concept
 title: Authentication process in ChaosCenter
-sidebar_label: Authentication in ChoasCenter
+sidebar_label: Authentication in ChaosCenter
 ---
 
 ---

--- a/website/versioned_docs/version-2.8.0/concepts/oauth-dex-concept.md
+++ b/website/versioned_docs/version-2.8.0/concepts/oauth-dex-concept.md
@@ -1,7 +1,7 @@
 ---
 id: oauth-dex-concept
 title: Authentication process in ChaosCenter
-sidebar_label: Authentication in ChoasCenter
+sidebar_label: Authentication in ChaosCenter
 ---
 
 ---

--- a/website/versioned_docs/version-2.9.0/concepts/oauth-dex-concept.md
+++ b/website/versioned_docs/version-2.9.0/concepts/oauth-dex-concept.md
@@ -1,7 +1,7 @@
 ---
 id: oauth-dex-concept
 title: Authentication process in ChaosCenter
-sidebar_label: Authentication in ChoasCenter
+sidebar_label: Authentication in ChaosCenter
 ---
 
 ---


### PR DESCRIPTION
Signed-off-by: hajowieland <mail@wieland.tech>

**What this PR does / why we need it**:

Just a small spelling fix in the Concept section of the sidebar in our documentation.


**Special notes for your reviewer**:

-- 

