### PR TITLE
Remove dead katacoda links

### DIFF
--- a/website/docs/getting-started/run-your-first-workflow.md
+++ b/website/docs/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Scenario with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)

--- a/website/versioned_docs/version-2.0.0/getting-started/run-your-first-workflow.md
+++ b/website/versioned_docs/version-2.0.0/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Workflow with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)

--- a/website/versioned_docs/version-2.1.0/getting-started/run-your-first-workflow.md
+++ b/website/versioned_docs/version-2.1.0/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Workflow with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)

--- a/website/versioned_docs/version-2.10.0/getting-started/run-your-first-workflow.md
+++ b/website/versioned_docs/version-2.10.0/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Workflow with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)

--- a/website/versioned_docs/version-2.11.0/getting-started/run-your-first-workflow.md
+++ b/website/versioned_docs/version-2.11.0/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Scenario with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)

--- a/website/versioned_docs/version-2.12.0/getting-started/run-your-first-workflow.md
+++ b/website/versioned_docs/version-2.12.0/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Scenario with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)

--- a/website/versioned_docs/version-2.13.0/getting-started/run-your-first-workflow.md
+++ b/website/versioned_docs/version-2.13.0/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Scenario with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)

--- a/website/versioned_docs/version-2.2.0/getting-started/run-your-first-workflow.md
+++ b/website/versioned_docs/version-2.2.0/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Workflow with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)

--- a/website/versioned_docs/version-2.3.0/getting-started/run-your-first-workflow.md
+++ b/website/versioned_docs/version-2.3.0/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Workflow with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)

--- a/website/versioned_docs/version-2.4.0/getting-started/run-your-first-workflow.md
+++ b/website/versioned_docs/version-2.4.0/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Workflow with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)

--- a/website/versioned_docs/version-2.5.0/getting-started/run-your-first-workflow.md
+++ b/website/versioned_docs/version-2.5.0/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Workflow with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)

--- a/website/versioned_docs/version-2.6.0/getting-started/run-your-first-workflow.md
+++ b/website/versioned_docs/version-2.6.0/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Workflow with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)

--- a/website/versioned_docs/version-2.7.0/getting-started/run-your-first-workflow.md
+++ b/website/versioned_docs/version-2.7.0/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Workflow with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)

--- a/website/versioned_docs/version-2.8.0/getting-started/run-your-first-workflow.md
+++ b/website/versioned_docs/version-2.8.0/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Workflow with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)

--- a/website/versioned_docs/version-2.9.0/getting-started/run-your-first-workflow.md
+++ b/website/versioned_docs/version-2.9.0/getting-started/run-your-first-workflow.md
@@ -138,4 +138,3 @@ And with that you have successfully scheduled your first Chaos Workflow with Lit
 
 - [Learn Concept](../concepts/overview.md)
 - [View User Guides](../user-guides/overview.md)
-- [Learn by Running a sample Katakoda Scenario](https://www.katacoda.com/litmusbot/scenarios/getting-started-with-litmus)


### PR DESCRIPTION
Signed-off-by: Yonathan Negussie Mengesha <yonathan.neg@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

[Katacoda](https://katacoda.com/) has been [shuttered](https://www.oreilly.com/online-learning/leveraging-katacoda-technology.html). This change removes the links in the documents.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Signed the commit for DCO to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag
