### PR TITLE
chore: add QnA to troubleshooting.md

### DIFF
--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -56,7 +56,7 @@ In the logs of the Helper pod, you may face these error logs below.
 {"mainLogs":"W1003 08:59:55.273647       1 client_config.go:552] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.\n2023/10/03 08:59:55 Error Creating Resource : ChaosEngine.litmuschaos.io 'pod-network-loss-h6srhrls' is invalid: [spec.experiments[0].spec.probe[0].runProperties.interval: Invalid value: 'string': spec.experiments[0].spec.probe[0].runProperties.interval in body must be of type integer: 'string', spec.experiments[0].spec.probe[0].runProperties.probeTimeout: Invalid value: 'string': spec.experiments[0].spec.probe[0].runProperties.probeTimeout in body must be of type integer: 'string']\n"}
 ```
 
-It's because your cluster using old CRD manifest files. So you need to delete all Litmus' CRDs and reinstall them. The definition for CRDs can be found in the Chaos Infrastructure YAML file or at this [link](https://github.com/litmuschaos/litmus/blob/master/mkdocs/docs/3.0.0/litmus-portal-crds-3.0.0.yml).
+It's because your cluster using old CRD manifest files. So you need to delete all Litmus' CRDs and reinstall them. The definition for CRDs can be found in the Chaos Infrastructure YAML file or at this [link](https://github.com/litmuschaos/litmus/blob/master/mkdocs/docs/<chaoscenter-version>/litmus-portal-crds-<chaoscenter-version>.yml).
 
 ## Chaoshub
 

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -48,6 +48,16 @@ You need to Provide the correct socket path. By default in Portal `CONTAINER_RUN
 If Your container runtime is `containerd` then you have to change the `CONTAINER_RUNTIME` to `containerd` and `SOCKET_PATH` to `/var/run/containerd/containerd.sock`.
 You can find these in tune faults part of the tune chaos experiment page.
 
+### The probe only accepts values in `ns, us, ms, m, s, or h`. But Why do experiments fail with `must be of type integer`?
+
+In the logs of the Helper pod, you may face these error logs below.
+
+```shell
+{"mainLogs":"W1003 08:59:55.273647       1 client_config.go:552] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.\n2023/10/03 08:59:55 Error Creating Resource : ChaosEngine.litmuschaos.io 'pod-network-loss-h6srhrls' is invalid: [spec.experiments[0].spec.probe[0].runProperties.interval: Invalid value: 'string': spec.experiments[0].spec.probe[0].runProperties.interval in body must be of type integer: 'string', spec.experiments[0].spec.probe[0].runProperties.probeTimeout: Invalid value: 'string': spec.experiments[0].spec.probe[0].runProperties.probeTimeout in body must be of type integer: 'string']\n"}
+```
+
+It's because your cluster using old CRD manifest files. So you need to delete all Litmus' CRDs and reinstall them. CRDs definition is in the Chaos Infrastructure yaml file.
+
 ## Chaoshub
 
 ### We have installed ChaosCenter successfully but the Litmus ChaosHub is in error state and manual cloning of a Git repository does not work.

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -56,7 +56,7 @@ In the logs of the Helper pod, you may face these error logs below.
 {"mainLogs":"W1003 08:59:55.273647       1 client_config.go:552] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.\n2023/10/03 08:59:55 Error Creating Resource : ChaosEngine.litmuschaos.io 'pod-network-loss-h6srhrls' is invalid: [spec.experiments[0].spec.probe[0].runProperties.interval: Invalid value: 'string': spec.experiments[0].spec.probe[0].runProperties.interval in body must be of type integer: 'string', spec.experiments[0].spec.probe[0].runProperties.probeTimeout: Invalid value: 'string': spec.experiments[0].spec.probe[0].runProperties.probeTimeout in body must be of type integer: 'string']\n"}
 ```
 
-It's because your cluster using old CRD manifest files. So you need to delete all Litmus' CRDs and reinstall them. CRDs definition is in the Chaos Infrastructure yaml file.
+It's because your cluster using old CRD manifest files. So you need to delete all Litmus' CRDs and reinstall them. The definition for CRDs can be found in the Chaos Infrastructure YAML file or at this [link](https://github.com/litmuschaos/litmus/blob/master/mkdocs/docs/3.0.0/litmus-portal-crds-3.0.0.yml).
 
 ## Chaoshub
 

--- a/website/versioned_docs/version-3.0.0/troubleshooting.md
+++ b/website/versioned_docs/version-3.0.0/troubleshooting.md
@@ -48,6 +48,16 @@ You need to Provide the correct socket path. By default in Portal `CONTAINER_RUN
 If Your container runtime is `containerd` then you have to change the `CONTAINER_RUNTIME` to `containerd` and `SOCKET_PATH` to `/var/run/containerd/containerd.sock`.
 You can find these in tune faults part of the tune chaos experiment page.
 
+### The probe only accepts values in `ns, us, ms, m, s, or h`. But Why do experiments fail with `must be of type integer`?
+
+In the logs of the Helper pod, you may face these error logs below.
+
+```shell
+{"mainLogs":"W1003 08:59:55.273647       1 client_config.go:552] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.\n2023/10/03 08:59:55 Error Creating Resource : ChaosEngine.litmuschaos.io 'pod-network-loss-h6srhrls' is invalid: [spec.experiments[0].spec.probe[0].runProperties.interval: Invalid value: 'string': spec.experiments[0].spec.probe[0].runProperties.interval in body must be of type integer: 'string', spec.experiments[0].spec.probe[0].runProperties.probeTimeout: Invalid value: 'string': spec.experiments[0].spec.probe[0].runProperties.probeTimeout in body must be of type integer: 'string']\n"}
+```
+
+It's because your cluster using old CRD manifest files. So you need to delete all Litmus' CRDs and reinstall them. CRDs definition is in the Chaos Infrastructure yaml file.
+
 ## Chaoshub
 
 ### We have installed ChaosCenter successfully but the Litmus ChaosHub is in error state and manual cloning of a Git repository does not work.

--- a/website/versioned_docs/version-3.0.0/troubleshooting.md
+++ b/website/versioned_docs/version-3.0.0/troubleshooting.md
@@ -56,7 +56,7 @@ In the logs of the Helper pod, you may face these error logs below.
 {"mainLogs":"W1003 08:59:55.273647       1 client_config.go:552] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.\n2023/10/03 08:59:55 Error Creating Resource : ChaosEngine.litmuschaos.io 'pod-network-loss-h6srhrls' is invalid: [spec.experiments[0].spec.probe[0].runProperties.interval: Invalid value: 'string': spec.experiments[0].spec.probe[0].runProperties.interval in body must be of type integer: 'string', spec.experiments[0].spec.probe[0].runProperties.probeTimeout: Invalid value: 'string': spec.experiments[0].spec.probe[0].runProperties.probeTimeout in body must be of type integer: 'string']\n"}
 ```
 
-It's because your cluster using old CRD manifest files. So you need to delete all Litmus' CRDs and reinstall them. CRDs definition is in the Chaos Infrastructure yaml file.
+It's because your cluster using old CRD manifest files. So you need to delete all Litmus' CRDs and reinstall them. The definition for CRDs can be found in the Chaos Infrastructure YAML file or at this [link](https://github.com/litmuschaos/litmus/blob/master/mkdocs/docs/3.0.0/litmus-portal-crds-3.0.0.yml).
 
 ## Chaoshub
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
I added a QnA to troubleshooting.md.

People who already applied old version of ChaosEngine CRD will face the error logs below.

```shell
{"mainLogs":"W1003 08:59:55.273647       1 client_config.go:552] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.\n2023/10/03 08:59:55 Error Creating Resource : ChaosEngine.litmuschaos.io 'pod-network-loss-h6srhrls' is invalid: [spec.experiments[0].spec.probe[0].runProperties.interval: Invalid value: 'string': spec.experiments[0].spec.probe[0].runProperties.interval in body must be of type integer: 'string', spec.experiments[0].spec.probe[0].runProperties.probeTimeout: Invalid value: 'string': spec.experiments[0].spec.probe[0].runProperties.probeTimeout in body must be of type integer: 'string']\n"}
```
So I added QnA about it.

reference: https://github.com/litmuschaos/litmus/pull/4205


**Special notes for your reviewer**: @Saranya-jena 

**Checklist:**
-   [ ] Fixes #<issue number>
-   [x] Signed the commit for DCO to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag
