### PR TITLE
docs: Add docs for Argo Workflow controller-instanceid label (#290)

### DIFF
--- a/website/docs/user-guides/construct-experiment.md
+++ b/website/docs/user-guides/construct-experiment.md
@@ -65,18 +65,23 @@ Here, the template with the name `custom-chaos` will be executed first.
 4. **Artifacts** : Artifacts are defined as the files saved by the containers in each step.
 
 ```yaml
-- name: install-chaos-experiments
-      inputs:
-        artifacts:
-          - name: pod-delete
-            path: /tmp/pod-delete.yaml
-            raw:
-              data: >
-                apiVersion: litmuschaos.io/v1alpha1
+-  name: install-chaos-experiments
+   inputs:
+     artifacts:
+       - name: pod-delete
+         path: /tmp/pod-delete.yaml
+         raw:
+           data: >
+             apiVersion: litmuschaos.io/v1alpha1
 
-                description:
-                  message: |...
+             description:
+               message: |...
 ```
+
+### Ensuring Your Workflow is Recognized by the Argo Workflow Controller
+
+When applying a Workflow manually without ChaosCenter, it's crucial to include the `workflows.argoproj.io/controller-instanceid` label in your YAML file. This label helps the controller identify and manage your Workflow correctly.
+The instanceID value can be found in the `workflow-controller-configmap` under the instanceID key.
 
 Once the chaos experiment is constructed, it should look like this:
 
@@ -86,6 +91,8 @@ kind: Workflow
 metadata:
   name: pod-delete-experiment
   namespace: litmus
+  labels:
+     workflows.argoproj.io/controller-instanceid: 86a4f130-d99b-4e91-b34b-8f9eee22cb63
 spec:
   arguments:
     parameters:

--- a/website/versioned_docs/version-3.10.0/user-guides/construct-experiment.md
+++ b/website/versioned_docs/version-3.10.0/user-guides/construct-experiment.md
@@ -65,18 +65,23 @@ Here, the template with the name `custom-chaos` will be executed first.
 4. **Artifacts** : Artifacts are defined as the files saved by the containers in each step.
 
 ```yaml
-- name: install-chaos-experiments
-      inputs:
-        artifacts:
-          - name: pod-delete
-            path: /tmp/pod-delete.yaml
-            raw:
-              data: >
-                apiVersion: litmuschaos.io/v1alpha1
+-  name: install-chaos-experiments
+   inputs:
+     artifacts:
+       - name: pod-delete
+         path: /tmp/pod-delete.yaml
+         raw:
+           data: >
+             apiVersion: litmuschaos.io/v1alpha1
 
-                description:
-                  message: |...
+             description:
+               message: |...
 ```
+
+### Ensuring Your Workflow is Recognized by the Argo Workflow Controller
+
+When applying a Workflow manually without ChaosCenter, it's crucial to include the `workflows.argoproj.io/controller-instanceid` label in your YAML file. This label helps the controller identify and manage your Workflow correctly.
+The instanceID value can be found in the `workflow-controller-configmap` under the instanceID key.
 
 Once the chaos scenario is constructed, it should look like this:
 
@@ -86,6 +91,8 @@ kind: Workflow
 metadata:
   name: pod-delete-experiment
   namespace: litmus
+  labels:
+     workflows.argoproj.io/controller-instanceid: 86a4f130-d99b-4e91-b34b-8f9eee22cb63
 spec:
   arguments:
     parameters:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Added a section to explain the requirement of the `workflows.argoproj.io/controller-instanceid` label in the Workflow YAML.
- Included an example showing where to add the label.
- Explained how to retrieve the instanceID value from the workflow-controller-configmap.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #290 

**Special notes for your reviewer**:

**Checklist:**
-   [x] Fixes #290 
-   [x] Signed the commit for DCO to be passed
-   [x] Labelled this PR & related issue with `documentation` tag
