### PR TITLE
docs: Add docs for Argo Workflow controller-instanceid label (#290)

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -70,7 +70,7 @@ To configure a git repo the user must provide the Git URL of the repository and 
 
 Once GitOps is enabled, any new chaos experiments created will be stored in the configured repo in the path `litmus/<project-id>/<chaos-experiment-name>.yaml`.
 
-### Why is my Argo Workflow not being picked up by the Workflow controller?
+### Why is my Argo Workflow not being picked up by the Workflow controller upon applying it manually?
 
 If your Argo Workflow is not being picked up by the Workflow controller after applying it, you may be missing the `workflows.argoproj.io/controller-instanceid` label in your Workflow YAML file. This label is required for the Workflow controller to manage the Workflow properly.
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -72,7 +72,7 @@ Once GitOps is enabled, any new chaos experiments created will be stored in the 
 
 ### Why is my Argo Workflow not being picked up by the Workflow controller upon applying it manually?
 
-If your Argo Workflow is not being picked up by the Workflow controller after applying it, you may be missing the `workflows.argoproj.io/controller-instanceid` label in your Workflow YAML file. This label is required for the Workflow controller to manage the Workflow properly.
+If your Argo Workflow is not being picked up by the Workflow controller after applying it, you may be missing the `workflows.argoproj.io/controller-instanceid` label in your Workflow manifest. This label is required for the Workflow controller to reconcile the Workflow upon its creation.
 
 To fix this, ensure the following label is added under metadata.labels in your Workflow YAML:
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -90,7 +90,7 @@ The `instanceID` value can be found in the `workflow-controller-configmap`. Here
 kubectl get configmap workflow-controller-configmap -n <namespace> -o yaml
 ```
 
-Look for the `instanceID` key in the configmap and use that value in your Workflow YAML.
+Look for the `instanceID` key in the configmap and use that value in your Workflow manifest.
 
 Without this label, the Workflow controller will not recognize or manage the Workflow.
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -70,6 +70,30 @@ To configure a git repo the user must provide the Git URL of the repository and 
 
 Once GitOps is enabled, any new chaos experiments created will be stored in the configured repo in the path `litmus/<project-id>/<chaos-experiment-name>.yaml`.
 
+### Why is my Argo Workflow not being picked up by the Workflow controller?
+
+If your Argo Workflow is not being picked up by the Workflow controller after applying it, you may be missing the `workflows.argoproj.io/controller-instanceid` label in your Workflow YAML file. This label is required for the Workflow controller to manage the Workflow properly.
+
+To fix this, ensure the following label is added under metadata.labels in your Workflow YAML:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  labels:
+    workflows.argoproj.io/controller-instanceid: <instanceID>
+```
+
+The `instanceID` value can be found in the `workflow-controller-configmap`. Here’s how to retrieve it:
+
+```shell
+kubectl get configmap workflow-controller-configmap -n <namespace> -o yaml
+```
+
+Look for the `instanceID` key in the configmap and use that value in your Workflow YAML.
+
+Without this label, the Workflow controller will not recognize or manage the Workflow.
+
 ## Litmusctl
 
 ### Does Litmusctl support actions that are currently performed from the portal dashboard?

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -74,7 +74,7 @@ Once GitOps is enabled, any new chaos experiments created will be stored in the 
 
 If your Argo Workflow is not being picked up by the Workflow controller after applying it, you may be missing the `workflows.argoproj.io/controller-instanceid` label in your Workflow manifest. This label is required for the Workflow controller to reconcile the Workflow upon its creation.
 
-To fix this, ensure the following label is added under metadata.labels in your Workflow YAML:
+To fix this, ensure the following label is added under `metadata.labels` field in the Workflow manifest:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -92,7 +92,7 @@ kubectl get configmap workflow-controller-configmap -n <namespace> -o yaml
 
 Look for the `instanceID` key in the configmap and use that value in your Workflow manifest.
 
-Without this label, the Workflow controller will not recognize or manage the Workflow.
+Without this label, the Workflow controller will not be able to reconcile the Workflow.
 
 ## Litmusctl
 

--- a/website/docs/user-guides/construct-experiment.md
+++ b/website/docs/user-guides/construct-experiment.md
@@ -80,7 +80,7 @@ Here, the template with the name `custom-chaos` will be executed first.
 
 ### Ensuring Your Workflow is Recognized by the Argo Workflow Controller
 
-When applying a Workflow manually without ChaosCenter, it's crucial to include the `workflows.argoproj.io/controller-instanceid` label in your YAML file. This label helps the controller identify and manage your Workflow correctly.
+When applying a Workflow manually without ChaosCenter, it's crucial to include the `workflows.argoproj.io/controller-instanceid` label in the manifest. This label helps Argo Workflow controller identify and reconcile the Workflow upon its creation.
 The instanceID value can be found in the `workflow-controller-configmap` under the instanceID key.
 
 Once the chaos experiment is constructed, it should look like this:

--- a/website/docs/user-guides/construct-experiment.md
+++ b/website/docs/user-guides/construct-experiment.md
@@ -65,18 +65,23 @@ Here, the template with the name `custom-chaos` will be executed first.
 4. **Artifacts** : Artifacts are defined as the files saved by the containers in each step.
 
 ```yaml
-- name: install-chaos-experiments
-      inputs:
-        artifacts:
-          - name: pod-delete
-            path: /tmp/pod-delete.yaml
-            raw:
-              data: >
-                apiVersion: litmuschaos.io/v1alpha1
+-  name: install-chaos-experiments
+   inputs:
+     artifacts:
+       - name: pod-delete
+         path: /tmp/pod-delete.yaml
+         raw:
+           data: >
+             apiVersion: litmuschaos.io/v1alpha1
 
-                description:
-                  message: |...
+             description:
+               message: |...
 ```
+
+### Ensuring Your Workflow is Recognized by the Argo Workflow Controller
+
+When applying a Workflow manually without ChaosCenter, it's crucial to include the `workflows.argoproj.io/controller-instanceid` label in your YAML file. This label helps the controller identify and manage your Workflow correctly.
+The instanceID value can be found in the `workflow-controller-configmap` under the instanceID key.
 
 Once the chaos experiment is constructed, it should look like this:
 
@@ -86,6 +91,8 @@ kind: Workflow
 metadata:
   name: pod-delete-experiment
   namespace: litmus
+  labels:
+     workflows.argoproj.io/controller-instanceid: 86a4f130-d99b-4e91-b34b-8f9eee22cb63
 spec:
   arguments:
     parameters:

--- a/website/versioned_docs/version-3.10.0/faq.md
+++ b/website/versioned_docs/version-3.10.0/faq.md
@@ -70,11 +70,11 @@ To configure a git repo the user must provide the Git URL of the repository and 
 
 Once GitOps is enabled, any new chaos experiments created will be stored in the configured repo in the path `litmus/<project-id>/<chaos-experiment-name>.yaml`.
 
-### Why is my Argo Workflow not being picked up by the Workflow controller?
+### Why is my Argo Workflow not being picked up by the Workflow controller upon applying it manually?
 
-If your Argo Workflow is not being picked up by the Workflow controller after applying it, you may be missing the `workflows.argoproj.io/controller-instanceid` label in your Workflow YAML file. This label is required for the Workflow controller to manage the Workflow properly.
+If your Argo Workflow is not being picked up by the Workflow controller after applying it, you may be missing the `workflows.argoproj.io/controller-instanceid` label in your Workflow manifest. This label is required for the Workflow controller to reconcile the Workflow upon its creation.
 
-To fix this, ensure the following label is added under metadata.labels in your Workflow YAML:
+To fix this, ensure the following label is added under `metadata.labels` field in the Workflow manifest:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -90,9 +90,9 @@ The `instanceID` value can be found in the `workflow-controller-configmap`. Here
 kubectl get configmap workflow-controller-configmap -n <namespace> -o yaml
 ```
 
-Look for the `instanceID` key in the configmap and use that value in your Workflow YAML.
+Look for the `instanceID` key in the configmap and use that value in your Workflow manifest.
 
-Without this label, the Workflow controller will not recognize or manage the Workflow.
+Without this label, the Workflow controller will not be able to reconcile the Workflow.
 
 ## Litmusctl
 

--- a/website/versioned_docs/version-3.10.0/faq.md
+++ b/website/versioned_docs/version-3.10.0/faq.md
@@ -70,6 +70,30 @@ To configure a git repo the user must provide the Git URL of the repository and 
 
 Once GitOps is enabled, any new chaos experiments created will be stored in the configured repo in the path `litmus/<project-id>/<chaos-experiment-name>.yaml`.
 
+### Why is my Argo Workflow not being picked up by the Workflow controller?
+
+If your Argo Workflow is not being picked up by the Workflow controller after applying it, you may be missing the `workflows.argoproj.io/controller-instanceid` label in your Workflow YAML file. This label is required for the Workflow controller to manage the Workflow properly.
+
+To fix this, ensure the following label is added under metadata.labels in your Workflow YAML:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  labels:
+    workflows.argoproj.io/controller-instanceid: <instanceID>
+```
+
+The `instanceID` value can be found in the `workflow-controller-configmap`. Here’s how to retrieve it:
+
+```shell
+kubectl get configmap workflow-controller-configmap -n <namespace> -o yaml
+```
+
+Look for the `instanceID` key in the configmap and use that value in your Workflow YAML.
+
+Without this label, the Workflow controller will not recognize or manage the Workflow.
+
 ## Litmusctl
 
 ### Does Litmusctl support actions that are currently performed from the portal dashboard?

--- a/website/versioned_docs/version-3.10.0/user-guides/construct-experiment.md
+++ b/website/versioned_docs/version-3.10.0/user-guides/construct-experiment.md
@@ -65,18 +65,23 @@ Here, the template with the name `custom-chaos` will be executed first.
 4. **Artifacts** : Artifacts are defined as the files saved by the containers in each step.
 
 ```yaml
-- name: install-chaos-experiments
-      inputs:
-        artifacts:
-          - name: pod-delete
-            path: /tmp/pod-delete.yaml
-            raw:
-              data: >
-                apiVersion: litmuschaos.io/v1alpha1
+-  name: install-chaos-experiments
+   inputs:
+     artifacts:
+       - name: pod-delete
+         path: /tmp/pod-delete.yaml
+         raw:
+           data: >
+             apiVersion: litmuschaos.io/v1alpha1
 
-                description:
-                  message: |...
+             description:
+               message: |...
 ```
+
+### Ensuring Your Workflow is Recognized by the Argo Workflow Controller
+
+When applying a Workflow manually without ChaosCenter, it's crucial to include the `workflows.argoproj.io/controller-instanceid` label in your YAML file. This label helps the controller identify and manage your Workflow correctly.
+The instanceID value can be found in the `workflow-controller-configmap` under the instanceID key.
 
 Once the chaos scenario is constructed, it should look like this:
 
@@ -86,6 +91,8 @@ kind: Workflow
 metadata:
   name: pod-delete-experiment
   namespace: litmus
+  labels:
+     workflows.argoproj.io/controller-instanceid: 86a4f130-d99b-4e91-b34b-8f9eee22cb63
 spec:
   arguments:
     parameters:

--- a/website/versioned_docs/version-3.10.0/user-guides/construct-experiment.md
+++ b/website/versioned_docs/version-3.10.0/user-guides/construct-experiment.md
@@ -80,7 +80,7 @@ Here, the template with the name `custom-chaos` will be executed first.
 
 ### Ensuring Your Workflow is Recognized by the Argo Workflow Controller
 
-When applying a Workflow manually without ChaosCenter, it's crucial to include the `workflows.argoproj.io/controller-instanceid` label in your YAML file. This label helps the controller identify and manage your Workflow correctly.
+When applying a Workflow manually without ChaosCenter, it's crucial to include the `workflows.argoproj.io/controller-instanceid` label in the manifest. This label helps Argo Workflow controller identify and reconcile the Workflow upon its creation.
 The instanceID value can be found in the `workflow-controller-configmap` under the instanceID key.
 
 Once the chaos scenario is constructed, it should look like this:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Added a section to explain the requirement of the `workflows.argoproj.io/controller-instanceid` label in the Workflow YAML.
- Included an example showing where to add the label.
- Explained how to retrieve the instanceID value from the workflow-controller-configmap.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #290 

**Special notes for your reviewer**:

**Checklist:**
-   [x] Fixes #290 
-   [x] Signed the commit for DCO to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag
