### PR TITLE
Relocate "How to Contribute" section to improve content structure

### DIFF
--- a/website/docs/introduction/community.md
+++ b/website/docs/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/docs/introduction/what-is-litmus.md
+++ b/website/docs/introduction/what-is-litmus.md
@@ -30,9 +30,4 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
 
-## How to Contribute
 
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.0.0/introduction/community.md
+++ b/website/versioned_docs/version-3.0.0/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.0.0/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.0.0/introduction/what-is-litmus.md
@@ -30,9 +30,3 @@ Chaos experiments are fundamental units within the LitmusChaos architecture. You
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving resilience.
 
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.1.0/introduction/community.md
+++ b/website/versioned_docs/version-3.1.0/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.1.0/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.1.0/introduction/what-is-litmus.md
@@ -29,10 +29,3 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 ## What is a Chaos Scenarios
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
-
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.10.0/introduction/community.md
+++ b/website/versioned_docs/version-3.10.0/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.10.0/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.10.0/introduction/what-is-litmus.md
@@ -29,10 +29,3 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 ## What is a Chaos Scenarios
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
-
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.11.0/introduction/community.md
+++ b/website/versioned_docs/version-3.11.0/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.11.0/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.11.0/introduction/what-is-litmus.md
@@ -29,10 +29,3 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 ## What is a Chaos Scenarios
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
-
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.12.0/introduction/community.md
+++ b/website/versioned_docs/version-3.12.0/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.12.0/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.12.0/introduction/what-is-litmus.md
@@ -29,10 +29,3 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 ## What is a Chaos Scenarios
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
-
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.2.0/introduction/community.md
+++ b/website/versioned_docs/version-3.2.0/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.2.0/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.2.0/introduction/what-is-litmus.md
@@ -29,10 +29,3 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 ## What is a Chaos Scenarios
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
-
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.3.0/introduction/community.md
+++ b/website/versioned_docs/version-3.3.0/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.3.0/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.3.0/introduction/what-is-litmus.md
@@ -29,10 +29,3 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 ## What is a Chaos Scenarios
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
-
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.4.0/introduction/community.md
+++ b/website/versioned_docs/version-3.4.0/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.4.0/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.4.0/introduction/what-is-litmus.md
@@ -29,10 +29,3 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 ## What is a Chaos Scenarios
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
-
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.5.0/introduction/community.md
+++ b/website/versioned_docs/version-3.5.0/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.5.0/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.5.0/introduction/what-is-litmus.md
@@ -29,10 +29,3 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 ## What is a Chaos Scenarios
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
-
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.6.0/introduction/community.md
+++ b/website/versioned_docs/version-3.6.0/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.6.0/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.6.0/introduction/what-is-litmus.md
@@ -29,10 +29,3 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 ## What is a Chaos Scenarios
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
-
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.7.0/introduction/community.md
+++ b/website/versioned_docs/version-3.7.0/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.7.0/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.7.0/introduction/what-is-litmus.md
@@ -29,10 +29,3 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 ## What is a Chaos Scenarios
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
-
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.8.0/introduction/community.md
+++ b/website/versioned_docs/version-3.8.0/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.8.0/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.8.0/introduction/what-is-litmus.md
@@ -29,10 +29,3 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 ## What is a Chaos Scenarios
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
-
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.9.0/introduction/community.md
+++ b/website/versioned_docs/version-3.9.0/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.9.0/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.9.0/introduction/what-is-litmus.md
@@ -29,10 +29,3 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 ## What is a Chaos Scenarios
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
-
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.9.1/introduction/community.md
+++ b/website/versioned_docs/version-3.9.1/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.9.1/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.9.1/introduction/what-is-litmus.md
@@ -29,10 +29,3 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 ## What is a Chaos Scenarios
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
-
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).

--- a/website/versioned_docs/version-3.9.2/introduction/community.md
+++ b/website/versioned_docs/version-3.9.2/introduction/community.md
@@ -66,6 +66,13 @@ We invite contributions in all forms. Join us in writing blogs on DEV.to about e
 
 [Go to dev.to](https://dev.to/t/litmuschaos)
 
+## How to Contribute
+
+- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
+- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
+- If you would like to work on something more involved, please connect with the Litmus Contributors.
+- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).
+
 ### Contribute your chaos experiments
 
 We are devoted to being an open source driven community and appeal to our community members to contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to develop LitmusChaos.

--- a/website/versioned_docs/version-3.9.2/introduction/what-is-litmus.md
+++ b/website/versioned_docs/version-3.9.2/introduction/what-is-litmus.md
@@ -29,10 +29,3 @@ Chaos Experiments are fundamental units within the LitmusChaos architecture. Use
 ## What is a Chaos Scenarios
 
 A chaos scenario is much more than a simple chaos experiment. It supports the user in defining the expected result, observing the result, analysing the overall system behaviour, and in the decision-making process if the system needs to be tuned for improving the resilience.
-
-## How to Contribute
-
-- If you are a first-time contributor, please see [Steps to Contribute](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#steps-to-contribute-).
-- If you would like to suggest new tests to be added to litmus, please go ahead and [create a new issue](https://github.com/litmuschaos/litmus/issues/new) describing your test. All you need to do is specify the workload type and the operations that you would like to perform on the workload.
-- If you would like to work on something more involved, please connect with the Litmus Contributors.
-- If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md#sign-your-work).


### PR DESCRIPTION
**What this PR does / why we need it**:

Moved the "How to Contribute" section from the "What is Litmus" page to the "Community" page under the "Contribute" section. This aligns the documentation with CNCF Tech Doc recommendations by separating introductory content from advanced contributor information.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #299 #294 

**Special notes for your reviewer**:

**Checklist:**
-   [X] Fixes #299 
-   [X] Signed the commit for DCO to be passed
