### PR TITLE
chore: update docs for local users

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -75,6 +75,14 @@ helm install chaos litmuschaos/litmus --namespace=litmus --set portal.frontend.s
 
 > **Note:** If your Kubernetes cluster isn't local, you may want not to expose Litmus via `NodePort`. If so, remove `--set portal.frontend.service.type=NodePort` option. To connect to Litmus UI from your laptop, you can use `port-forward svc/chaos-litmus-frontend-service 9091:9091`. Then you can use your browser and open `127.0.0.1:9091`.
 
+- If your Kubernetes cluster is local (such as minikube or kind) and only accessing Litmus locally, please replace the default endpoint with your custom CHAOS_CENTER_UI_ENDPOINT as shown below.
+
+  ```bash
+  helm install chaos litmuschaos/litmus --namespace=litmus \
+  --set portal.frontend.service.type=NodePort \
+  --set portal.server.graphqlServer.genericEnv.CHAOS_CENTER_UI_ENDPOINT=http://chaos-litmus-frontend-service.litmus.svc.cluster.local:9091
+  ```
+
 - Litmus helm chart depends on `bitnami/mongodb` [helm chart](https://github.com/bitnami/charts/tree/main/bitnami/mongodb), which uses a mongodb image not supported on ARM. If you want to install Litmus on an ARM-based server, please replace the default one with your custom mongodb arm image as shown below.
 
   ```bash

--- a/website/versioned_docs/version-3.12.0/getting-started/installation.md
+++ b/website/versioned_docs/version-3.12.0/getting-started/installation.md
@@ -75,6 +75,14 @@ helm install chaos litmuschaos/litmus --namespace=litmus --set portal.frontend.s
 
 > **Note:** If your Kubernetes cluster isn't local, you may want not to expose Litmus via `NodePort`. If so, remove `--set portal.frontend.service.type=NodePort` option. To connect to Litmus UI from your laptop, you can use `port-forward svc/chaos-litmus-frontend-service 9091:9091`. Then you can use your browser and open `127.0.0.1:9091`.
 
+- If your Kubernetes cluster is local (such as minikube or kind) and only accessing Litmus locally, please replace the default endpoint with your custom CHAOS_CENTER_UI_ENDPOINT as shown below.
+
+  ```bash
+  helm install chaos litmuschaos/litmus --namespace=litmus \
+  --set portal.frontend.service.type=NodePort \
+  --set portal.server.graphqlServer.genericEnv.CHAOS_CENTER_UI_ENDPOINT=http://chaos-litmus-frontend-service.litmus.svc.cluster.local:9091
+  ```
+
 - Litmus helm chart depends on `bitnami/mongodb` [helm chart](https://github.com/bitnami/charts/tree/main/bitnami/mongodb), which uses a mongodb image not supported on ARM. If you want to install Litmus on an ARM-based server, please replace the default one with your custom mongodb arm image as shown below.
 
   ```bash


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
If we access chaoscenter as localhost or 127.0.0.1 (if we run litmus on local), when creating chaos infrastructure, the subscriber pod will receive an invalid server_addr and the connection will be refused like below.

```bash
time="2024-11-23T09:06:13Z" level=fatal msg="Failed to confirm agent" data= error="Post \"http://localhost:30000/api/query\": dial tcp [::1]:30000: connect: connection refused"
```

 This PR adds clarification to make it easier for users to install helm locally.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/litmuschaos/litmus/issues/4892 https://github.com/litmuschaos/litmus/issues/4798

**Special notes for your reviewer**:

**Checklist:**
-   [x] Fixes fixes https://github.com/litmuschaos/litmus/issues/4892 https://github.com/litmuschaos/litmus/issues/4798
-   [x] Signed the commit for DCO to be passed
-   [x] Labelled this PR & related issue with `documentation` tag
