### PR TITLE
Refactor documentation: Transfer Instructional Content from Concepts to User Guide for Improved Clarity

### DIFF
--- a/website/docs/concepts/chaoshub.md
+++ b/website/docs/concepts/chaoshub.md
@@ -12,87 +12,11 @@ A ChaosHub is a collection of experiment templates and faults that you can use t
 
 - Chaos experiments can be created from the public [ChaosHub](http://hub.litmuschaos.io/) which is already connected to your ChaosCenter, or a custom ChaosHub which is a [fork](https://github.com/litmuschaos/chaos-charts) of the public ChaosHub where custom faults can be stored.
 
-## Prerequisites
-
-The following are the prerequisites for creating a Chaos Experiment:
-
-- Fork of [Chaos-Charts](https://github.com/litmuschaos/chaos-charts) repository
-
-:::note
-An active internet connection is required to clone the git repository for the first time installation.
-:::
-
-## Connecting to a Git repository using ChaosHub
-
-With ChaosHub, you can construct chaos experiments by selecting, tuning and sequencing different faults together from their connected ChaosHubs.
-
-You can make changes in your forked repositories and sync it with the Portal to get the latest changes from the fork.
-
-By default, a public ChaosHub is provided when the ChaosCenter is installed for the first time.
-
-<img src={require('../assets/concepts/chaoshub/chaoshub-default.png').default} width="800" />
-
-### 1. Connect a public Git repository
-
-You can connect to a public Git repository by simply providing the following details:
-
-- Hub name
-- Git URL of the forked repository
-- Branch name
-
-<img src={require('../assets/concepts/chaoshub/chaoshub-add-public.png').default} width="800" />
-
-### 2. Connect a private Git repository
-
-To add a private ChaosHub, you need provide the hub name, Git URL of the forked repository and the branch name similar to that of public hub and the repository can be connected in two ways:
-
-<img src={require('../assets/concepts/chaoshub/chaoshub-add-private.png').default} width="800" />
-
-#### a. Access token
-
-Personal Access Tokens are used as an alternative to the password for authentication to Git services.
-
-#### b. SSH key
-
-Just like the Access Token , SSH keys are used for the authentication. These keys come in pairs, a public key that is shared with the Git Services and a private key that is stored with you.
-SSH link of the repository should be provided if you select this method.
-
-<img src={require('../assets/concepts/chaoshub/chaoshub-after-add.png').default} width="800" />
-
-## Syncing a ChaosHub
-
-If some changes are made into the Git repository, you can reflect these changes in the hub by selecting the **Refresh Hub** option from the ChaosHub card.
-
-## Editing a ChaosHub
-
-To make changes in a hub like changing the name, branch, access token etc, you can select the **Edit Hub** option from the ChaosHub card.
-
 ## Chaos experiments and experiments in a ChaosHub
 
-### 1. View the PreDefined Chaos Experiments
+For information on viewing predefined chaos experiments, refer to [Viewing Predefined Chaos Experiments](../user-guides/viewing-predefined-experiments.md).
 
-After connecting a ChaosHub, you can view the different pre-defined chaos experiments present in the ChaosHub.
-
-<img src={require('../assets/concepts/chaoshub/chaoshub-predefined-experiments.png').default} width="800" />
-
-### 2. View the Chaos Faults
-
-Similarly, you can view the different charts and the fault. These charts are sorted according to different categories like generic, AWS, Azure, Kube-Components etc.
-
-<img src={require('../assets/concepts/chaoshub/chaoshub-chaos-charts.png').default} width="800" />
-
-### 3. View the fault details
-
-You can select one of the chaos faults and can examine the fault details. The fault page consists of all the important details like the description of the fault, a tutorial video, the maintainer of the fault, etc.
-
-You can also find the Experiment manifest URL, RBAC URL, and the ChaosEngine URLs of the fault.
-These URLs are required for the creation of custom chaos experiments.
-
-<img src={require('../assets/concepts/chaoshub/chaoshub-exp-details.png').default} width="800" />
-
-## Disconnect a ChaosHub
-
-To remove a ChaosHub from a project, you can select the **Disconnect Hub** option from the ChaosHub card.
+For information on viewing chaos faults and their details, refer to [Viewing Chaos Faults](../user-guides/viewing-chaos-faults.md).
 
 ## Summary
 

--- a/website/docs/concepts/gitops.md
+++ b/website/docs/concepts/gitops.md
@@ -6,7 +6,7 @@ sidebar_label: GitOps
 
 ---
 
-## Prerequisites
+## Related concepts
 
 - Chaos Infrastructure
 - [Chaos Experiment](chaos-workflow.md)

--- a/website/docs/concepts/oauth-dex-concept.md
+++ b/website/docs/concepts/oauth-dex-concept.md
@@ -6,7 +6,7 @@ sidebar_label: Authentication in ChaosCenter
 
 ---
 
-## Prerequisites
+## Related concepts
 
 - [OAuth](https://oauth.net/specs/)
 

--- a/website/docs/concepts/probes.md
+++ b/website/docs/concepts/probes.md
@@ -8,7 +8,7 @@ sidebar_label: Resilience Probes
 
 Resilience Probes are pluggable checks that can be defined within the ChaosEngine for any Chaos Experiment. The fault pods execute these checks based on the mode they are defined in & factor their success as necessary conditions in determining the verdict of the fault (along with the standard `in-built` checks).
 
-## Prerequisites
+## Related concepts
 
 To understand the concepts of Probes better make sure you are aware of the [ChaosEngine](glossary.md) Custom Resources and promql queries (for Prometheus Probes)
 

--- a/website/docs/concepts/projects.md
+++ b/website/docs/concepts/projects.md
@@ -8,7 +8,7 @@ sidebar_label: Projects
 
 The ChaosCenter comes with a project management system that can be used for working on chaos experiments with multiple different projects across different chaos infrastructures.
 
-## Prerequisites
+## Related concepts
 
 Before learning about the concept of projects, it is important to note that a project signifies a separation between Chaos infrastructures, Schedules, [Visualization](visualize-experiment.md), and Teams (discussed in the next section) configurations, and prior knowledge of these will prove fruitful in understanding the concept of projects in-depth.
 

--- a/website/docs/concepts/teaming.md
+++ b/website/docs/concepts/teaming.md
@@ -1,6 +1,6 @@
 ---
 id: teaming
-title: Collaborate with teams
+title: Team Collaboration
 sidebar_label: Teaming
 ---
 

--- a/website/docs/user-guides/connecting-git-repo.md
+++ b/website/docs/user-guides/connecting-git-repo.md
@@ -1,0 +1,60 @@
+---
+id: connecting-git-repo
+title: Connecting to a Git Repository
+sidebar_label: Connecting Git Repo
+---
+
+## Prerequisites
+
+The following are the prerequisites for creating a Chaos Experiment:
+
+- Fork of [Chaos-Charts](https://github.com/litmuschaos/chaos-charts) repository
+
+:::note
+An active internet connection is required to clone the git repository for the first time installation.
+:::
+
+## Connecting to a Git repository using ChaosHub
+
+With ChaosHub, you can construct chaos experiments by selecting, tuning and sequencing different faults together from their connected ChaosHubs.
+
+You can make changes in your forked repositories and sync it with the Portal to get the latest changes from the fork.
+
+By default, a public ChaosHub is provided when the ChaosCenter is installed for the first time.
+
+<img src={require('../assets/concepts/chaoshub/chaoshub-default.png').default} width="800" />
+
+### 1. Connect a public Git repository
+
+You can connect to a public Git repository by simply providing the following details:
+
+- Hub name
+- Git URL of the forked repository
+- Branch name
+
+<img src={require('../assets/concepts/chaoshub/chaoshub-add-public.png').default} width="800" />
+
+### 2. Connect a private Git repository
+
+To add a private ChaosHub, you need provide the hub name, Git URL of the forked repository and the branch name similar to that of public hub and the repository can be connected in two ways:
+
+<img src={require('../assets/concepts/chaoshub/chaoshub-add-private.png').default} width="800" />
+
+#### a. Access token
+
+Personal Access Tokens are used as an alternative to the password for authentication to Git services.
+
+#### b. SSH key
+
+Just like the Access Token , SSH keys are used for the authentication. These keys come in pairs, a public key that is shared with the Git Services and a private key that is stored with you.
+SSH link of the repository should be provided if you select this method.
+
+<img src={require('../assets/concepts/chaoshub/chaoshub-after-add.png').default} width="800" />
+
+## Syncing a ChaosHub
+
+If some changes are made into the Git repository, you can reflect these changes in the hub by selecting the **Refresh Hub** option from the ChaosHub card.
+
+## Editing a ChaosHub
+
+To make changes in a hub like changing the name, branch, access token etc, you can select the **Edit Hub** option from the ChaosHub card.

--- a/website/docs/user-guides/removing-chaoshub.md
+++ b/website/docs/user-guides/removing-chaoshub.md
@@ -1,0 +1,7 @@
+---
+id: removing-chaoshub
+title: Removing a ChaosHub
+sidebar_label: Removing a ChaosHUb
+---
+
+To remove a ChaosHub from a project, you can select the **Disconnect Hub** option from the ChaosHub card.

--- a/website/docs/user-guides/viewing-chaos-faults.md
+++ b/website/docs/user-guides/viewing-chaos-faults.md
@@ -1,0 +1,20 @@
+---
+id: viewing-chaos-faults
+title: Viewing Chaos Faults
+sidebar_label: Viewing Chaos Faults
+---
+
+### Viewing Chaos Faults
+
+After connecting a ChaosHub, you can view the different chaos charts and faults. These charts are categorized into different sections such as generic, AWS, Azure, Kube-Components, etc.
+
+<img src={require('../assets/concepts/chaoshub/chaoshub-chaos-charts.png').default} width="800" />
+
+### View the fault details
+
+You can select one of the chaos faults and can examine the fault details. The fault page consists of all the important details like the description of the fault, a tutorial video, the maintainer of the fault, etc.
+
+You can also find the Experiment manifest URL, RBAC URL, and the ChaosEngine URLs of the fault.
+These URLs are required for the creation of custom chaos experiments.
+
+<img src={require('../assets/concepts/chaoshub/chaoshub-exp-details.png').default} width="800" />

--- a/website/docs/user-guides/viewing-predefined-experiments.md
+++ b/website/docs/user-guides/viewing-predefined-experiments.md
@@ -1,0 +1,10 @@
+---
+id: viewing-predefined-experiments
+title: Viewing Predefined Chaos Experiments
+sidebar_label: Viewing Predefined Experiments
+---
+
+
+After connecting a ChaosHub, you can view the different pre-defined chaos experiments present in the ChaosHub.
+
+<img src={require('../assets/concepts/chaoshub/chaoshub-predefined-experiments.png').default} width="800" />

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -39,6 +39,7 @@ module.exports = {
     {
       'User Guides': [
         'user-guides/overview',
+        'user-guides/connecting-git-repo',
         {
           'Advanced Installation': [
             {
@@ -93,6 +94,7 @@ module.exports = {
         {
           'Managing Projects': ['user-guides/change-project-name', 'user-guides/leave-project']
         },
+        'user-guides/removing-chaoshub',
         {
           Teaming: [
             'user-guides/invite-team-member',
@@ -103,7 +105,9 @@ module.exports = {
         },
         'user-guides/gitops-configuration',
         'user-guides/image-registry',
-        'user-guides/uninstall-litmus'
+        'user-guides/uninstall-litmus',
+        'user-guides/viewing-predefined-experiments',
+        'user-guides/viewing-chaos-faults',
       ]
     },
     {

--- a/website/versioned_docs/version-3.12.0/concepts/chaoshub.md
+++ b/website/versioned_docs/version-3.12.0/concepts/chaoshub.md
@@ -12,87 +12,11 @@ A ChaosHub is a collection of experiment templates and faults that you can use t
 
 - Chaos experiments can be created from the public [ChaosHub](http://hub.litmuschaos.io/) which is already connected to your ChaosCenter, or a custom ChaosHub which is a [fork](https://github.com/litmuschaos/chaos-charts) of the public ChaosHub where custom faults can be stored.
 
-## Prerequisites
-
-The following are the prerequisites for creating a Chaos Experiment:
-
-- Fork of [Chaos-Charts](https://github.com/litmuschaos/chaos-charts) repository
-
-:::note
-An active internet connection is required to clone the git repository for the first time installation.
-:::
-
-## Connecting to a Git repository using ChaosHub
-
-With ChaosHub, you can construct chaos experiments by selecting, tuning and sequencing different faults together from their connected ChaosHubs.
-
-You can make changes in your forked repositories and sync it with the Portal to get the latest changes from the fork.
-
-By default, a public ChaosHub is provided when the ChaosCenter is installed for the first time.
-
-<img src={require('../assets/concepts/chaoshub/chaoshub-default.png').default} width="800" />
-
-### 1. Connect a public Git repository
-
-You can connect to a public Git repository by simply providing the following details:
-
-- Hub name
-- Git URL of the forked repository
-- Branch name
-
-<img src={require('../assets/concepts/chaoshub/chaoshub-add-public.png').default} width="800" />
-
-### 2. Connect a private Git repository
-
-To add a private ChaosHub, you need provide the hub name, Git URL of the forked repository and the branch name similar to that of public hub and the repository can be connected in two ways:
-
-<img src={require('../assets/concepts/chaoshub/chaoshub-add-private.png').default} width="800" />
-
-#### a. Access token
-
-Personal Access Tokens are used as an alternative to the password for authentication to Git services.
-
-#### b. SSH key
-
-Just like the Access Token , SSH keys are used for the authentication. These keys come in pairs, a public key that is shared with the Git Services and a private key that is stored with you.
-SSH link of the repository should be provided if you select this method.
-
-<img src={require('../assets/concepts/chaoshub/chaoshub-after-add.png').default} width="800" />
-
-## Syncing a ChaosHub
-
-If some changes are made into the Git repository, you can reflect these changes in the hub by selecting the **Refresh Hub** option from the ChaosHub card.
-
-## Editing a ChaosHub
-
-To make changes in a hub like changing the name, branch, access token etc, you can select the **Edit Hub** option from the ChaosHub card.
-
 ## Chaos experiments and experiments in a ChaosHub
 
-### 1. View the PreDefined Chaos Experiments
+For information on viewing predefined chaos experiments, refer to [Viewing Predefined Chaos Experiments](../user-guides/viewing-predefined-experiments.md).
 
-After connecting a ChaosHub, you can view the different pre-defined chaos experiments present in the ChaosHub.
-
-<img src={require('../assets/concepts/chaoshub/chaoshub-predefined-experiments.png').default} width="800" />
-
-### 2. View the Chaos Faults
-
-Similarly, you can view the different charts and the fault. These charts are sorted according to different categories like generic, AWS, Azure, Kube-Components etc.
-
-<img src={require('../assets/concepts/chaoshub/chaoshub-chaos-charts.png').default} width="800" />
-
-### 3. View the fault details
-
-You can select one of the chaos faults and can examine the fault details. The fault page consists of all the important details like the description of the fault, a tutorial video, the maintainer of the fault, etc.
-
-You can also find the Experiment manifest URL, RBAC URL, and the ChaosEngine URLs of the fault.
-These URLs are required for the creation of custom chaos experiments.
-
-<img src={require('../assets/concepts/chaoshub/chaoshub-exp-details.png').default} width="800" />
-
-## Disconnect a ChaosHub
-
-To remove a ChaosHub from a project, you can select the **Disconnect Hub** option from the ChaosHub card.
+For information on viewing chaos faults and their details, refer to [Viewing Chaos Faults](../user-guides/viewing-chaos-faults.md).
 
 ## Summary
 

--- a/website/versioned_docs/version-3.12.0/concepts/gitops.md
+++ b/website/versioned_docs/version-3.12.0/concepts/gitops.md
@@ -6,7 +6,7 @@ sidebar_label: GitOps
 
 ---
 
-## Prerequisites
+## Related concepts
 
 - Chaos Infrastructure
 - [Chaos Experiment](chaos-workflow.md)

--- a/website/versioned_docs/version-3.12.0/concepts/oauth-dex-concept.md
+++ b/website/versioned_docs/version-3.12.0/concepts/oauth-dex-concept.md
@@ -6,7 +6,7 @@ sidebar_label: Authentication in ChaosCenter
 
 ---
 
-## Prerequisites
+## Related concepts
 
 - [OAuth](https://oauth.net/specs/)
 

--- a/website/versioned_docs/version-3.12.0/concepts/probes.md
+++ b/website/versioned_docs/version-3.12.0/concepts/probes.md
@@ -8,7 +8,7 @@ sidebar_label: Resilience Probes
 
 Resilience Probes are pluggable checks that can be defined within the ChaosEngine for any Chaos Experiment. The fault pods execute these checks based on the mode they are defined in & factor their success as necessary conditions in determining the verdict of the fault (along with the standard `in-built` checks).
 
-## Prerequisites
+## Related concepts
 
 To understand the concepts of Probes better make sure you are aware of the [ChaosEngine](glossary.md) Custom Resources and promql queries (for Prometheus Probes)
 

--- a/website/versioned_docs/version-3.12.0/concepts/projects.md
+++ b/website/versioned_docs/version-3.12.0/concepts/projects.md
@@ -8,7 +8,7 @@ sidebar_label: Projects
 
 The ChaosCenter comes with a project management system that can be used for working on chaos experiments with multiple different projects across different chaos infrastructures.
 
-## Prerequisites
+## Related concepts
 
 Before learning about the concept of projects, it is important to note that a project signifies a separation between Chaos infrastructures, Schedules, [Visualization](visualize-experiment.md), and Teams (discussed in the next section) configurations, and prior knowledge of these will prove fruitful in understanding the concept of projects in-depth.
 

--- a/website/versioned_docs/version-3.12.0/concepts/teaming.md
+++ b/website/versioned_docs/version-3.12.0/concepts/teaming.md
@@ -1,6 +1,6 @@
 ---
 id: teaming
-title: Collaborate with teams
+title: Team Collaboration
 sidebar_label: Teaming
 ---
 

--- a/website/versioned_docs/version-3.12.0/user-guides/connecting-git-repo.md
+++ b/website/versioned_docs/version-3.12.0/user-guides/connecting-git-repo.md
@@ -1,0 +1,60 @@
+---
+id: connecting-git-repo
+title: Connecting to a Git Repository
+sidebar_label: Connecting Git Repo
+---
+
+## Prerequisites
+
+The following are the prerequisites for creating a Chaos Experiment:
+
+- Fork of [Chaos-Charts](https://github.com/litmuschaos/chaos-charts) repository
+
+:::note
+An active internet connection is required to clone the git repository for the first time installation.
+:::
+
+## Connecting to a Git repository using ChaosHub
+
+With ChaosHub, you can construct chaos experiments by selecting, tuning and sequencing different faults together from their connected ChaosHubs.
+
+You can make changes in your forked repositories and sync it with the Portal to get the latest changes from the fork.
+
+By default, a public ChaosHub is provided when the ChaosCenter is installed for the first time.
+
+<img src={require('../assets/concepts/chaoshub/chaoshub-default.png').default} width="800" />
+
+### 1. Connect a public Git repository
+
+You can connect to a public Git repository by simply providing the following details:
+
+- Hub name
+- Git URL of the forked repository
+- Branch name
+
+<img src={require('../assets/concepts/chaoshub/chaoshub-add-public.png').default} width="800" />
+
+### 2. Connect a private Git repository
+
+To add a private ChaosHub, you need provide the hub name, Git URL of the forked repository and the branch name similar to that of public hub and the repository can be connected in two ways:
+
+<img src={require('../assets/concepts/chaoshub/chaoshub-add-private.png').default} width="800" />
+
+#### a. Access token
+
+Personal Access Tokens are used as an alternative to the password for authentication to Git services.
+
+#### b. SSH key
+
+Just like the Access Token , SSH keys are used for the authentication. These keys come in pairs, a public key that is shared with the Git Services and a private key that is stored with you.
+SSH link of the repository should be provided if you select this method.
+
+<img src={require('../assets/concepts/chaoshub/chaoshub-after-add.png').default} width="800" />
+
+## Syncing a ChaosHub
+
+If some changes are made into the Git repository, you can reflect these changes in the hub by selecting the **Refresh Hub** option from the ChaosHub card.
+
+## Editing a ChaosHub
+
+To make changes in a hub like changing the name, branch, access token etc, you can select the **Edit Hub** option from the ChaosHub card.

--- a/website/versioned_docs/version-3.12.0/user-guides/removing-chaoshub.md
+++ b/website/versioned_docs/version-3.12.0/user-guides/removing-chaoshub.md
@@ -1,0 +1,7 @@
+---
+id: removing-chaoshub
+title: Removing a ChaosHub
+sidebar_label: Removing a ChaosHUb
+---
+
+To remove a ChaosHub from a project, you can select the **Disconnect Hub** option from the ChaosHub card.

--- a/website/versioned_docs/version-3.12.0/user-guides/viewing-chaos-faults.md
+++ b/website/versioned_docs/version-3.12.0/user-guides/viewing-chaos-faults.md
@@ -1,0 +1,18 @@
+---
+id: viewing-chaos-faults
+title: Viewing Chaos Faults
+sidebar_label: Viewing Chaos Faults
+---
+
+After connecting a ChaosHub, you can view the different chaos charts and faults. These charts are categorized into different sections such as generic, AWS, Azure, Kube-Components, etc.
+
+<img src={require('../assets/concepts/chaoshub/chaoshub-chaos-charts.png').default} width="800" />
+
+### View the fault details
+
+You can select one of the chaos faults and can examine the fault details. The fault page consists of all the important details like the description of the fault, a tutorial video, the maintainer of the fault, etc.
+
+You can also find the Experiment manifest URL, RBAC URL, and the ChaosEngine URLs of the fault.
+These URLs are required for the creation of custom chaos experiments.
+
+<img src={require('../assets/concepts/chaoshub/chaoshub-exp-details.png').default} width="800" />

--- a/website/versioned_docs/version-3.12.0/user-guides/viewing-predefined-experiments.md
+++ b/website/versioned_docs/version-3.12.0/user-guides/viewing-predefined-experiments.md
@@ -1,0 +1,10 @@
+---
+id: viewing-predefined-experiments
+title: Viewing Predefined Chaos Experiments
+sidebar_label: Viewing Predefined Experiments
+---
+
+
+After connecting a ChaosHub, you can view the different pre-defined chaos experiments present in the ChaosHub.
+
+<img src={require('../assets/concepts/chaoshub/chaoshub-predefined-experiments.png').default} width="800" />

--- a/website/versioned_sidebars/version-3.12.0-sidebars.json
+++ b/website/versioned_sidebars/version-3.12.0-sidebars.json
@@ -42,6 +42,7 @@
     {
       "User Guides": [
         "user-guides/overview",
+        "user-guides/connecting-git-repo",
         {
           "Advanced Installation": [
             {
@@ -102,6 +103,7 @@
             "user-guides/leave-project"
           ]
         },
+        "user-guides/removing-chaoshub",
         {
           "Teaming": [
             "user-guides/invite-team-member",
@@ -112,7 +114,9 @@
         },
         "user-guides/gitops-configuration",
         "user-guides/image-registry",
-        "user-guides/uninstall-litmus"
+        "user-guides/uninstall-litmus",
+        "user-guides/viewing-predefined-experiments",
+        "user-guides/viewing-chaos-faults"
       ]
     },
     {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request addresses the feature request to reorganize the Litmus docs by consolidating instructional material into the User Guide and updating terminology for clarity. The following changes have been made:

- Moved procedural content related to ChaosHub (connecting to Git repositories, syncing, editing, etc.), chaos experiments, and other instructional sections from the Concepts section to the User Guide.
- Replaced the term "Prerequisites" with "Related concepts" in sections like Resilience Probe, GitOps, and Authentication to reflect conceptual content rather than actionable steps.
- Renamed the "Collaborate with teams" section to "Team Collaboration" for consistency with documentation standards.

**Which issue this PR fixes** 
 - fixes #307 

**Special notes for your reviewer**:

**Checklist:**
-   [X] Fixes #307 
-   [X] Signed the commit for DCO to be passed