### PR TITLE
fix: correct FAQ link in the footer

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -29,7 +29,7 @@ const resources = [
   },
   {
     label: 'FAQ',
-    href: 'https://docs.litmuschaos.io/docs/faq-general/'
+    href: 'https://docs.litmuschaos.io/docs/faq/'
   },
   {
     label: 'Issues',


### PR DESCRIPTION

**Description:**

This PR updates the FAQ link in the footer to the correct URL. The previous link was pointing to the wrong destination, and now it has been corrected to lead to the accurate FAQ page.

## Related Issue
- Fixes *#319*.

**Changes Made:**

- Updated the FAQ link in the footer from:
  
  ```js
  href: 'https://docs.litmuschaos.io/docs/faq-general/'
  ```

  to:

  ```js
  href: 'https://docs.litmuschaos.io/docs/faq/'
  ```

**Steps to Verify:**

1. Open the website.
2. Scroll down to the footer section.
3. Click on the FAQ link.
4. Verify that it directs you to the correct FAQ page.

**Impact:**

This update ensures that users can navigate to the correct FAQ page without encountering errors or being redirected to an incorrect link.

---

Feel free to adjust the wording if needed! Let me know if you'd like to add anything else.

**Special notes for your reviewer**:

**Checklist:**
-   [x] Fixes #<issue number>
-   [x] Signed the commit for DCO to be passed
-   [x] Labelled this PR & related issue with `documentation` tag
