### PR TITLE
docs: fix typo in integration/prometheus page

### DIFF
--- a/website/docs/integrations/prometheus.md
+++ b/website/docs/integrations/prometheus.md
@@ -174,7 +174,7 @@ spec:
       - litmus
   podMetricsEndpoints:
     - port: tcp
-    - interval: 1s
+      interval: 1s
       metricRelabelings:
         - targetLabel: instance
           replacement: 'chaos-exporter-service'


### PR DESCRIPTION
### *Description:*  
This PR corrects a typo in the *Prometheus integration documentation* under the section:  
📌 *"Prometheus community version (helm) - kube-prometheus-stack with pod monitor"*  

The original PodMonitor configuration incorrectly scraped metrics from all pods with a TCP port. 
 
## Related Issue
- Fixes #143.

### *Changes Made:*  
- *File Modified:* docs/integrations/prometheus.md  
- *Fixed Typo in:* PodMonitor example configuration  

*Special notes for your reviewer*:

*Checklist:*
-   [x] Fixes #143 
-   [x] Signed the commit for DCO to be passed
-   [ ] Labelled this PR & related issue with documentation tag