### PR TITLE
Added glossary reference in chaos fault flow

### DIFF
--- a/website/docs/architecture/chaos-experiment-flow.md
+++ b/website/docs/architecture/chaos-experiment-flow.md
@@ -35,5 +35,5 @@ With the latest release of LitmusChaos 3.0.0:
 - The term **Chaos Experiment** has been changed to **Chaos Fault**.
 - The term **Chaos Scenario/Workflow** has been changed to **Chaos Experiment**.
 
-Refer to the [Glossary](https://docs.litmuschaos.io/docs/next/architecture/chaos-fault-flow) doc for more info.
+Refer to the [Glossary](../glossary.md) doc for more info.
 :::

--- a/website/docs/architecture/chaos-experiment-flow.md
+++ b/website/docs/architecture/chaos-experiment-flow.md
@@ -34,4 +34,6 @@ With the latest release of LitmusChaos 3.0.0:
 - The term **Chaos Delegate/Agent** has been changed to **Chaos Infrastructure**.
 - The term **Chaos Experiment** has been changed to **Chaos Fault**.
 - The term **Chaos Scenario/Workflow** has been changed to **Chaos Experiment**.
+
+Refer to the [Glossary](https://docs.litmuschaos.io/docs/next/architecture/chaos-fault-flow) doc for more info.
 :::


### PR DESCRIPTION

#373 Add reference to Glossary in Notes section of Chaos Fault Flow doc

Added the following line under the Notes section:
Refer to the [Glossary](https://docs.litmuschaos.io/docs/next/architecture/chaos-fault-flow) doc for more info.