### PR TITLE
docs(gitops): add hyperlink for Chaos Infrastructure in prerequisites…

### DIFF
--- a/website/docs/concepts/gitops.md
+++ b/website/docs/concepts/gitops.md
@@ -8,7 +8,7 @@ sidebar_label: GitOps
 
 ## Prerequisites
 
-- Chaos Infrastructure
+- [Chaos Infrastructure](infrastructure.md)
 - [Chaos Experiment](chaos-workflow.md)
 
 The GitOps feature in Litmus enables you to configure a single source of truth for your chaos experiments and faults, any changes made either to the artifacts stored in the configured git repository or the portal will be synced. This allows you to create and execute chaos experiments directly from git enabling a vast scope of automation in CI/CD pipelines.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

Summary of Changes
- Updated the GitOps documentation prerequisites section (`website/docs/concepts/gitops.md`).
- Added a hyperlink to **Chaos Infrastructure** pointing to its detailed documentation page.
- Ensured hyperlink formatting matches other docs for consistency.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #358 

**Special notes for your reviewer**:

How Has This Been Tested?
- Verified that the hyperlink renders correctly in Markdown preview.
- Checked consistency with other hyperlinks in the documentation.

**Checklist:**
-   [x] Fixes #358 
-   [x] Signed the commit for DCO to be passed
-   [x] Labelled this PR & related issue with `documentation` tag
